### PR TITLE
Fix json-validation recursion bug

### DIFF
--- a/packages/host/tests/unit/qs-test.ts
+++ b/packages/host/tests/unit/qs-test.ts
@@ -1,7 +1,11 @@
 import qs from 'qs';
 import { module, test } from 'qunit';
 
-import { parseQuery, Query } from '@cardstack/runtime-common/query';
+import {
+  parseQuery,
+  Query,
+  assertQuery,
+} from '@cardstack/runtime-common/query';
 
 module('Unit | qs | parse', function () {
   test('parseQuery errors out if the query is too deep', async function (assert) {
@@ -53,5 +57,26 @@ module('Unit | qs | parse', function () {
     });
     let parsedQuery: any = parseQuery(queryString);
     assert.deepEqual(parsedQuery, query);
+  });
+
+  test('assertQuery checks all items in every filter', async function (assert) {
+    let queryString =
+      'filter[every][0][eq][name]=Mango&filter[every][1]=not-a-filter';
+    let query = parseQuery(queryString);
+    assert.throws(
+      () => assertQuery(query),
+      /missing filter object/,
+      'invalid filter entry triggers error',
+    );
+  });
+
+  test('assertQuery validates range filter keys', async function (assert) {
+    let queryString = 'filter[range][age][gt]=10&filter[range][age][foo]=20';
+    let query = parseQuery(queryString);
+    assert.throws(
+      () => assertQuery(query),
+      /range item must be gt, gte, lt, or lte/,
+      'invalid range key triggers error',
+    );
   });
 });

--- a/packages/runtime-common/json-validation.ts
+++ b/packages/runtime-common/json-validation.ts
@@ -9,13 +9,13 @@ export function assertJSONValue(v: any, pointer: string[]) {
       return;
     case 'object':
       if (Array.isArray(v)) {
-        v.every((value, index) =>
-          assertJSONValue(value, pointer.concat(`[${index}]`)),
-        );
+        v.forEach((value, index) => {
+          assertJSONValue(value, pointer.concat(`[${index}]`));
+        });
       } else {
-        Object.entries(v).every(([key, value]) =>
-          assertJSONValue(value, pointer.concat(key)),
-        );
+        Object.entries(v).forEach(([key, value]) => {
+          assertJSONValue(value, pointer.concat(key));
+        });
       }
       return;
   }

--- a/packages/runtime-common/query.ts
+++ b/packages/runtime-common/query.ts
@@ -301,9 +301,9 @@ function assertAnyFilter(
       `${pointer.join('/') || '/'}: any must be an array of Filters`,
     );
   } else {
-    filter.any.every((value: any, index: number) =>
-      assertFilter(value, pointer.concat(`[${index}]`)),
-    );
+    filter.any.forEach((value: any, index: number) => {
+      assertFilter(value, pointer.concat(`[${index}]`));
+    });
   }
 }
 
@@ -431,14 +431,14 @@ function assertRangeFilter(
       `${pointer.join('/') || '/'}: range must be an object`,
     );
   }
-  Object.entries(filter.range).every(([fieldPath, constraints]) => {
+  Object.entries(filter.range).forEach(([fieldPath, constraints]) => {
     let innerPointer = [...pointer, fieldPath];
     if (typeof constraints !== 'object' || constraints == null) {
       throw new InvalidQueryError(
         `${innerPointer.join('/') || '/'}: range constraint must be an object`,
       );
     }
-    Object.entries(constraints).every(([key, value]) => {
+    Object.entries(constraints).forEach(([key, value]) => {
       switch (key) {
         case 'gt':
         case 'gte':


### PR DESCRIPTION
## Summary
- fix loops in JSON validation to traverse full data structures
- fix filter validation loops
- add tests covering invalid filters

## Testing
- `pnpm --filter ./packages/host lint:js`
- `pnpm --filter ./packages/host test` *(fails: missing modules)*