### PR TITLE
Fix bot response for command results without output

### DIFF
--- a/packages/ai-bot/lib/responder.ts
+++ b/packages/ai-bot/lib/responder.ts
@@ -15,6 +15,7 @@ import type { ChatCompletionSnapshot } from 'openai/lib/ChatCompletionStream';
 import {
   APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
   APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE,
+  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 import { MatrixEvent as DiscreteMatrixEvent } from 'matrix-js-sdk';
 
@@ -27,16 +28,16 @@ export class Responder {
       return true;
     }
 
-    // If it's a command result with output, we might respond
-    if (
-      event.getType() === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE &&
-      event.getContent().msgtype ===
-        APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE
-    ) {
-      return true;
+    // If it's a command result, we might respond regardless of output
+    if (event.getType() === APP_BOXEL_COMMAND_RESULT_EVENT_TYPE) {
+      let msgtype = event.getContent().msgtype;
+      return (
+        msgtype === APP_BOXEL_COMMAND_RESULT_WITH_OUTPUT_MSGTYPE ||
+        msgtype === APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE
+      );
     }
 
-    // If it's a different type, or a command result without output, we should not respond
+    // If it's a different type, we should not respond
     return false;
   }
 

--- a/packages/ai-bot/tests/responding-test.ts
+++ b/packages/ai-bot/tests/responding-test.ts
@@ -7,8 +7,11 @@ import { CommandRequest } from '@cardstack/runtime-common/commands';
 import {
   APP_BOXEL_REASONING_CONTENT_KEY,
   APP_BOXEL_COMMAND_REQUESTS_KEY,
+  APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+  APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
 } from '@cardstack/runtime-common/matrix-constants';
 import type OpenAI from 'openai';
+import { MatrixEvent } from 'matrix-js-sdk';
 import { FakeMatrixClient } from './helpers/fake-matrix-client';
 
 function snapshotWithContent(content: string): ChatCompletionSnapshot {
@@ -100,6 +103,20 @@ module('Responding', (hooks) => {
     clock.uninstall();
     responder.finalize();
     fakeMatrixClient.resetSentEvents();
+  });
+
+  test('eventMayTriggerResponse returns true for command result without output', () => {
+    let event = new MatrixEvent({
+      type: APP_BOXEL_COMMAND_RESULT_EVENT_TYPE,
+      content: {
+        msgtype: APP_BOXEL_COMMAND_RESULT_WITH_NO_OUTPUT_MSGTYPE,
+      },
+    } as any);
+
+    assert.true(
+      Responder.eventMayTriggerResponse(event),
+      'Command result with no output should trigger a response',
+    );
   });
 
   test('Sends thinking message', async () => {


### PR DESCRIPTION
## Summary
- ensure `Responder.eventMayTriggerResponse` handles command results with no output
- test that command results without output trigger a response

## Testing
- `pnpm --filter @cardstack/ai-bot test`