### PR TITLE
Add timestamp to AI user message context

### DIFF
--- a/packages/ai-bot/helpers.ts
+++ b/packages/ai-bot/helpers.ts
@@ -650,6 +650,7 @@ export async function getModifyPrompt(
   ) {
     throw new Error("Username must be a full id, e.g. '@ai-bot:localhost'");
   }
+  let currentDateTime = new Date().toISOString();
   let historicalMessages: OpenAIPromptMessage[] = [];
   for (let event of history) {
     if (event.type !== 'm.room.message') {
@@ -698,10 +699,10 @@ export async function getModifyPrompt(
         body = `User message: ${body}
           Context: the user has the following cards open: ${JSON.stringify(
             event.content.data.context.openCardIds,
-          )}`;
+          )}. Current date and time: ${currentDateTime}`;
       } else {
         body = `User message: ${body}
-          Context: the user has no open cards.`;
+          Context: the user has no open cards. Current date and time: ${currentDateTime}`;
       }
       historicalMessages.push({
         role: 'user',

--- a/packages/ai-bot/tests/prompt-construction-test.ts
+++ b/packages/ai-bot/tests/prompt-construction-test.ts
@@ -122,9 +122,10 @@ module('getModifyPrompt', (hooks) => {
     assert.equal(result.length, 2);
     assert.equal(result[0].role, 'system');
     assert.equal(result[1].role, 'user');
-    assert.equal(
-      result[1].content,
-      'User message: Hey\n          Context: the user has no open cards.',
+    assert.ok(
+      result[1].content?.startsWith(
+        'User message: Hey\n          Context: the user has no open cards. Current date and time:',
+      ),
     );
   });
 


### PR DESCRIPTION
## Summary
- include current date/time in AI bot's user message context
- update prompt construction test for the new timestamp

## Testing
- `pnpm --filter @cardstack/ai-bot lint:js`
- `pnpm --filter @cardstack/ai-bot test`