### PR TITLE
Add credit check to proxy endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -266,6 +266,7 @@ jobs:
             "search-prerendered-test.ts",
             "types-endpoint-test.ts",
             "server-endpoints-test.ts",
+            "proxy-endpoint-test.ts",
             "virtual-network-test.ts",
           ]
     steps:

--- a/packages/billing/billing-queries.ts
+++ b/packages/billing/billing-queries.ts
@@ -59,6 +59,14 @@ export interface LedgerEntry {
   subscriptionCycleId: string | null;
 }
 
+export interface ProxyCall {
+  id: string;
+  userId: string;
+  url: string;
+  creditsSpent: number;
+  createdAt: number;
+}
+
 function planRowToPlan(row: Record<string, PgPrimitive>): Plan {
   return {
     id: row.id,
@@ -560,4 +568,28 @@ export async function spendCredits(
       });
     }
   }
+}
+
+export async function insertProxyCall(
+  dbAdapter: DBAdapter,
+  params: { userId: string; url: string; creditsSpent: number },
+): Promise<ProxyCall> {
+  let { valueExpressions, nameExpressions } = asExpressions({
+    user_id: params.userId,
+    url: params.url,
+    credits_spent: params.creditsSpent,
+  });
+
+  let result = await query(
+    dbAdapter,
+    insert('api_proxy_calls', nameExpressions, valueExpressions),
+  );
+
+  return {
+    id: result[0].id,
+    userId: result[0].user_id,
+    url: result[0].url,
+    creditsSpent: result[0].credits_spent,
+    createdAt: result[0].created_at,
+  } as ProxyCall;
 }

--- a/packages/postgres/migrations/1737600000000_create-api-proxy-calls.js
+++ b/packages/postgres/migrations/1737600000000_create-api-proxy-calls.js
@@ -1,0 +1,22 @@
+exports.up = (pgm) => {
+  pgm.createTable('api_proxy_calls', {
+    id: {
+      type: 'uuid',
+      primaryKey: true,
+      default: pgm.func('gen_random_uuid()'),
+    },
+    user_id: { type: 'uuid', references: 'users(id)' },
+    url: { type: 'varchar', notNull: true },
+    credits_spent: { type: 'integer', notNull: true },
+    created_at: {
+      type: 'integer',
+      notNull: true,
+      default: pgm.func('EXTRACT(epoch FROM CURRENT_TIMESTAMP)::integer'),
+    },
+  });
+  pgm.createIndex('api_proxy_calls', 'user_id');
+};
+
+exports.down = (pgm) => {
+  pgm.dropTable('api_proxy_calls');
+};

--- a/packages/realm-server/handlers/handle-proxy.ts
+++ b/packages/realm-server/handlers/handle-proxy.ts
@@ -1,0 +1,96 @@
+import { SupportedMimeType } from '@cardstack/runtime-common';
+import Koa from 'koa';
+import {
+  fetchRequestFromContext,
+  sendResponseForBadRequest,
+  sendResponseForSystemError,
+  sendResponseForPaymentRequired,
+  setContextResponse,
+} from '../middleware';
+import { RealmServerTokenClaim } from '../utils/jwt';
+import {
+  getUserByMatrixUserId,
+  spendCredits,
+  insertProxyCall,
+  sumUpCreditsLedger,
+} from '@cardstack/billing/billing-queries';
+import { CreateRoutesArgs } from '../routes';
+
+const PROXY_CREDIT_COST = 1;
+
+export default function handleProxyRequest({
+  dbAdapter,
+}: CreateRoutesArgs): (ctxt: Koa.Context, next: Koa.Next) => Promise<void> {
+  return async function (ctxt: Koa.Context) {
+    let token = ctxt.state.token as RealmServerTokenClaim;
+    if (!token) {
+      await sendResponseForSystemError(
+        ctxt,
+        'token is required to proxy request',
+      );
+      return;
+    }
+
+    let { user: matrixUserId } = token;
+    let user = await getUserByMatrixUserId(dbAdapter, matrixUserId);
+    if (!user) {
+      await sendResponseForSystemError(ctxt, 'user not found');
+      return;
+    }
+
+    let request = await fetchRequestFromContext(ctxt);
+    let bodyText = await request.text();
+    let params: {
+      url: string;
+      method?: string;
+      headers?: Record<string, string>;
+      body?: any;
+    };
+    try {
+      params = JSON.parse(bodyText);
+    } catch (e) {
+      await sendResponseForBadRequest(ctxt, 'Request body is not valid JSON');
+      return;
+    }
+
+    if (!params.url) {
+      await sendResponseForBadRequest(ctxt, 'url is required');
+      return;
+    }
+
+    let availableCredits = await sumUpCreditsLedger(dbAdapter, {
+      userId: user.id,
+    });
+    if (availableCredits < PROXY_CREDIT_COST) {
+      await sendResponseForPaymentRequired(ctxt, 'Not enough credits');
+      return;
+    }
+
+    let response = await fetch(params.url, {
+      method: params.method ?? 'GET',
+      headers: params.headers,
+      body: params.body,
+    });
+
+    let responseBody = await response.text();
+
+    await spendCredits(dbAdapter, user.id, PROXY_CREDIT_COST);
+    await insertProxyCall(dbAdapter, {
+      userId: user.id,
+      url: params.url,
+      creditsSpent: PROXY_CREDIT_COST,
+    });
+
+    return setContextResponse(
+      ctxt,
+      new Response(responseBody, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: {
+          'content-type':
+            response.headers.get('content-type') || SupportedMimeType.JSON,
+        },
+      }),
+    );
+  };
+}

--- a/packages/realm-server/middleware/index.ts
+++ b/packages/realm-server/middleware/index.ts
@@ -177,6 +177,13 @@ export async function sendResponseForForbiddenRequest(
   await sendResponseForError(ctxt, 401, 'Forbidden Request', message);
 }
 
+export async function sendResponseForPaymentRequired(
+  ctxt: Koa.Context,
+  message: string,
+) {
+  await sendResponseForError(ctxt, 402, 'Payment Required', message);
+}
+
 export async function sendResponseForSystemError(
   ctxt: Koa.Context,
   message: string,

--- a/packages/realm-server/routes.ts
+++ b/packages/realm-server/routes.ts
@@ -11,6 +11,7 @@ import Koa from 'koa';
 import handleStripeLinksRequest from './handlers/handle-stripe-links';
 import handleCreateUserRequest from './handlers/handle-create-user';
 import handleQueueStatusRequest from './handlers/handle-queue-status';
+import handleProxyRequest from './handlers/handle-proxy';
 
 export type CreateRoutesArgs = {
   dbAdapter: DBAdapter;
@@ -63,6 +64,11 @@ export function createRoutes(args: CreateRoutesArgs) {
     handleCreateUserRequest(args),
   );
   router.get('/_stripe-links', handleStripeLinksRequest());
+  router.post(
+    '/_proxy',
+    jwtMiddleware(args.realmSecretSeed),
+    handleProxyRequest(args),
+  );
 
   return router.routes();
 }

--- a/packages/realm-server/tests/index.ts
+++ b/packages/realm-server/tests/index.ts
@@ -22,6 +22,7 @@ import './realm-endpoints/search-test';
 import './realm-endpoints/user-test';
 import './search-prerendered-test';
 import './server-endpoints-test';
+import './proxy-endpoint-test';
 import './types-endpoint-test';
 import './virtual-network-test';
 import './billing-test';

--- a/packages/realm-server/tests/proxy-endpoint-test.ts
+++ b/packages/realm-server/tests/proxy-endpoint-test.ts
@@ -1,0 +1,165 @@
+import { module, test } from 'qunit';
+import { Test, SuperTest } from 'supertest';
+import { join, basename } from 'path';
+import { dirSync, type DirResult } from 'tmp';
+import { copySync } from 'fs-extra';
+import { baseRealm, query, param } from '@cardstack/runtime-common';
+import {
+  setupCardLogs,
+  setupBaseRealmServer,
+  setupPermissionedRealm,
+  createVirtualNetworkAndLoader,
+  matrixURL,
+  realmSecretSeed,
+  insertUser,
+  insertPlan,
+} from './helpers';
+import '@cardstack/runtime-common/helpers/code-equality-assertion';
+import { type PgAdapter } from '@cardstack/postgres';
+import { createJWT as createRealmServerJWT } from '../utils/jwt';
+import {
+  insertSubscription,
+  insertSubscriptionCycle,
+  addToCreditsLedger,
+  sumUpCreditsLedger,
+} from '@cardstack/billing/billing-queries';
+
+module(basename(__filename), function () {
+  module('Server Endpoint | POST _proxy', function (hooks) {
+    let request: SuperTest<Test>;
+    let dir: DirResult;
+    let dbAdapter: PgAdapter;
+
+    let { virtualNetwork, loader } = createVirtualNetworkAndLoader();
+
+    function onRealmSetup(args: {
+      request: SuperTest<Test>;
+      dir: DirResult;
+      dbAdapter: PgAdapter;
+    }) {
+      request = args.request;
+      dir = args.dir;
+      dbAdapter = args.dbAdapter;
+    }
+
+    setupCardLogs(
+      hooks,
+      async () => await loader.import(`${baseRealm.url}card-api`),
+    );
+
+    setupBaseRealmServer(hooks, virtualNetwork, matrixURL);
+
+    hooks.beforeEach(async function () {
+      dir = dirSync();
+      copySync(join(__dirname, 'cards'), dir.name);
+    });
+
+    setupPermissionedRealm(hooks, {
+      permissions: {
+        '*': ['read', 'write'],
+      },
+      onRealmSetup,
+    });
+
+    hooks.beforeEach(function () {
+      virtualNetwork.mount(
+        async (req: Request) => {
+          if (req.url === 'http://external.service/data') {
+            return new Response(JSON.stringify({ data: 123 }), {
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+          return null;
+        },
+        { prepend: true },
+      );
+    });
+
+    test('proxy call deducts credits and returns response', async function (assert) {
+      let user = await insertUser(
+        dbAdapter,
+        'user@test',
+        'cus_123',
+        'user@test.com',
+      );
+      let plan = await insertPlan(dbAdapter, 'Basic', 0, 10, 'prod_basic');
+      let subscription = await insertSubscription(dbAdapter, {
+        user_id: user.id,
+        plan_id: plan.id,
+        started_at: 1,
+        status: 'active',
+        stripe_subscription_id: 'sub_123',
+      });
+      let cycle = await insertSubscriptionCycle(dbAdapter, {
+        subscriptionId: subscription.id,
+        periodStart: 1,
+        periodEnd: 2,
+      });
+      await addToCreditsLedger(dbAdapter, {
+        userId: user.id,
+        creditAmount: 10,
+        creditType: 'plan_allowance',
+        subscriptionCycleId: cycle.id,
+      });
+
+      let response = await request
+        .post('/_proxy')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set(
+          'Authorization',
+          `Bearer ${createRealmServerJWT({ user: 'user@test', sessionRoom: 'room' }, realmSecretSeed)}`,
+        )
+        .send({ url: 'http://external.service/data' });
+
+      assert.strictEqual(response.status, 200, 'HTTP 200 status');
+      assert.deepEqual(response.body, { data: 123 });
+
+      assert.strictEqual(
+        await sumUpCreditsLedger(dbAdapter, { userId: user.id }),
+        9,
+      );
+      let rows = await query(dbAdapter, [
+        `SELECT * FROM api_proxy_calls WHERE user_id = `,
+        param(user.id),
+      ]);
+      assert.strictEqual(rows.length, 1, 'proxy call logged');
+      assert.strictEqual(rows[0].url, 'http://external.service/data');
+    });
+
+    test('proxy call fails with 402 when credits are insufficient', async function (assert) {
+      let user = await insertUser(
+        dbAdapter,
+        'no-credits@test',
+        'cus_456',
+        'no-credits@test.com',
+      );
+      let plan = await insertPlan(dbAdapter, 'Basic', 0, 10, 'prod_basic');
+      let subscription = await insertSubscription(dbAdapter, {
+        user_id: user.id,
+        plan_id: plan.id,
+        started_at: 1,
+        status: 'active',
+        stripe_subscription_id: 'sub_456',
+      });
+      await insertSubscriptionCycle(dbAdapter, {
+        subscriptionId: subscription.id,
+        periodStart: 1,
+        periodEnd: 2,
+      });
+
+      let response = await request
+        .post('/_proxy')
+        .set('Accept', 'application/json')
+        .set('Content-Type', 'application/json')
+        .set(
+          'Authorization',
+          `Bearer ${createRealmServerJWT({ user: 'no-credits@test', sessionRoom: 'room' }, realmSecretSeed)}`,
+        )
+        .send({ url: 'http://external.service/data' });
+
+      assert.strictEqual(response.status, 402, 'HTTP 402 status');
+      assert.strictEqual(response.body.errors[0], 'Not enough credits');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add helper for 402 responses
- validate available credits before proxying
- test 402 error when user has no credits

## Testing
- `pnpm --filter @cardstack/realm-server lint:js`
- `pnpm --filter @cardstack/realm-server test` *(fails: docker not found)*